### PR TITLE
Add scalaz.zio.IO, fromTryCatch

### DIFF
--- a/scalafix.conf
+++ b/scalafix.conf
@@ -70,7 +70,6 @@ Disable.symbols = [
     }
     message = "not a total function"
   }
-
 ]
 
 Disable.ifSynthetic = [
@@ -105,6 +104,7 @@ Disable.unlessInside = [
       "fommil/std/IO"
       "scalaz/ioeffect/IO"
       "scalaz/ioeffect/Task"
+      "scalaz/zio/IO"
     ]
     symbols = [
       {
@@ -148,7 +148,12 @@ Disable.unlessInside = [
   }
   {
     safeBlocks = [
-      "scalaz/Maybe.attempt"
+# https://github.com/scalacenter/scalafix/issues/777
+#      "scalaz/\\/.fromTryCatchNonFatal",
+#      "scalaz/\\/.fromTryCatchThrowable",
+      "scalaz/Maybe.attempt",
+      "scalaz/Maybe.fromTryCatchNonFatal",
+      "scalaz/Maybe.fromTryCatchThrowable"
     ]
     symbols = [
       {
@@ -161,7 +166,7 @@ Disable.unlessInside = [
           excludes = [
           ]
         }
-        message = "Deterministic method is not total, must be called via Maybe.attempt"
+        message = "Deterministic method is not total, must be called via Maybe.attempt, \/.fromTryCatchNonFatal, etc."
       }
     ]
   }


### PR DESCRIPTION
I really wanted `\/.fromTryCatchThrowable` but I guess that does not work (at least I could not figure it out).
Either way, `Maybe.attempt` does not exist in Scalaz 7.3...

scalacenter/scalafix#777