### PR TITLE
Update config for scalafix 0.9.4

### DIFF
--- a/scalafix.conf
+++ b/scalafix.conf
@@ -11,8 +11,10 @@ rules = [
   ExplicitResultTypes
   LeakingImplicitClassVal
   MissingFinal
-  RemoveUnusedImports
-  RemoveUnusedTerms
+  NoAutoTupling
+  NoValInForComprehension
+  ProcedureSyntax
+  RemoveUnused
 ]
 
 Disable.symbols = [
@@ -29,10 +31,12 @@ Disable.symbols = [
     message = "scala arbitrary precision numbers are broken: https://github.com/scala/bug/issues/9670"
   }
   {
-    regex = [
-      "^\\Qjava/io\\E.*$"
-      "^\\Qscala/io\\E.*$"
-    ]
+    regex = {
+      includes = [
+        "^\\Qjava/io\\E.*$"
+        "^\\Qscala/io/Source\\E.*$"
+      ]
+    }
     message = "legacy blocking API, prefer java.nio"
   }
   {
@@ -43,7 +47,6 @@ Disable.symbols = [
     regex = {
       includes = [
         # overrides not fully implemented: https://github.com/scalacenter/scalafix/pull/634
-        "^.*\\Q#asInstanceOf().\\E$"
         "^.*\\Q#equals().\\E$"
         "^.*\\Q#hashCode().\\E$"
         "^.*\\Q#toString().\\E$" # doesn't catch string interpolators...
@@ -104,7 +107,21 @@ Disable.unlessInside = [
       "fommil/std/IO"
       "scalaz/ioeffect/IO"
       "scalaz/ioeffect/Task"
+      "scalaz/ApplicativeError.handleError"
+      "scalaz/ApplicativeError.raiseError"
+      "scalaz/syntax/ApplicativeErrorOps.handleError"
+      "scalaz/syntax/ApplicativeErrorOps.recover"
+      "scalaz/syntax/MonadErrorOps.emap"
       "scalaz/zio/IO"
+      "scalaz/zio/Task"
+      "scalaz/zio/UIO"
+      "scalaz/zio/ZIO"
+      "scalaz/zio/ZIO_E_Throwable.effect"
+      "scalaz/zio/ZIOFunctions.effectAsync"
+      "scalaz/zio/ZIOFunctions.effectTotal"
+      "scalaz/zio/ZIOFunctions.effectTotalWith"
+      "scalaz/zio/ZIOFunctions.fail"
+      "scalaz/zio/ZIOFunctions.halt"
     ]
     symbols = [
       {
@@ -172,20 +189,30 @@ Disable.unlessInside = [
   }
 ]
 
-DisableSyntax.keywords = [
-  var
-  null
-  return
-  throw
-  while
-]
-DisableSyntax.noSemicolons = true
-DisableSyntax.noXml = true
-DisableSyntax.noCovariantTypes = true
-DisableSyntax.noContravariantTypes = true
-DisableSyntax.noValInAbstract = true
-DisableSyntax.noImplicitObject = true
-DisableSyntax.noImplicitConversion = true
+DisableSyntax {
+  noSemicolons = true
+  noXml = true
+  noCovariantTypes = true
+  noContravariantTypes = true
+  noImplicitObject = true
+  noImplicitConversion = true
+  noTabs = true
+  noDefaultArgs = true
+  noValInAbstract = false
+  noImplicitObject = true
+  noImplicitConversion = true
+  noFinalVal = true
+  noFinalize = true
+  noVars = true
+  noThrows = true
+  noNulls = true
+  noReturns = true
+  noWhileLoops = true
+  noAsInstanceOf = true
+  noIsInstanceOf = true
+  noValPatterns = false
+  noUniversalEquality = true
+}
 
 ExplicitResultTypes {
   unsafeShortenNames = true

--- a/scalafix.conf
+++ b/scalafix.conf
@@ -190,28 +190,26 @@ Disable.unlessInside = [
 ]
 
 DisableSyntax {
-  noSemicolons = true
-  noXml = true
-  noCovariantTypes = true
+  noAsInstanceOf = true
   noContravariantTypes = true
-  noImplicitObject = true
-  noImplicitConversion = true
-  noTabs = true
+  noCovariantTypes = true
   noDefaultArgs = true
-  noValInAbstract = false
-  noImplicitObject = true
-  noImplicitConversion = true
   noFinalVal = true
   noFinalize = true
-  noVars = true
-  noThrows = true
+  noImplicitConversion = true
+  noImplicitObject = true
+  noIsInstanceOf = true
   noNulls = true
   noReturns = true
-  noWhileLoops = true
-  noAsInstanceOf = true
-  noIsInstanceOf = true
-  noValPatterns = false
+  noSemicolons = true
+  noTabs = true
+  noThrows = true
   noUniversalEquality = true
+  noValInAbstract = true
+  noValPatterns = true
+  noVars = true
+  noWhileLoops = true
+  noXml = true
 }
 
 ExplicitResultTypes {


### PR DESCRIPTION
It's 2019 and some rules/configs have changed.

- No longer ban `do` because it needs `while` to compile, which is banned
- Some more 'safe blocks' for optin stuffs
- Only ban `scala.io.Source` for being blocking instead of the whole `scala.io` package